### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A comprehensive **Model Context Protocol (MCP)** server that provides seamless integration between AI assistants (like Claude Desktop) and the Spotify Web API. This server enables AI assistants to interact with Spotify's music streaming service through a well-structured, type-safe interface.
 
+<a href="https://glama.ai/mcp/servers/@latiftplgu/Spotify-OAuth-MCP-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@latiftplgu/Spotify-OAuth-MCP-server/badge" alt="Spotify Server MCP server" />
+</a>
+
 ## 🎵 Overview
 
 This MCP server acts as a bridge between AI assistants and Spotify's Web API, allowing users to:


### PR DESCRIPTION
This PR adds a badge for the [Spotify MCP Server](https://glama.ai/mcp/servers/@latiftplgu/Spotify-OAuth-MCP-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@latiftplgu/Spotify-OAuth-MCP-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@latiftplgu/Spotify-OAuth-MCP-server/badge" alt="Spotify Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.